### PR TITLE
Instalar tinytex en el workflow de publicación

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
           version: 1.10.18
+          tinytex: true
 
       # Execution results are frozen (_freeze/), so publishing needs neither
       # Python nor the TextClassification datasets it downloads at render


### PR DESCRIPTION
El renderizado a PDF requiere una instalación de TeX (lualatex), y el
job de publish no la tenía instalada, causando el fallo en GitHub
Actions. Fixes #76