### PR TITLE
Instalar dependencias de Chrome headless y timeout en el workflow de publicación

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -22,6 +23,27 @@ jobs:
         with:
           version: 1.10.18
           tinytex: true
+
+      # Mismas librerías que .devcontainer/postCreate.sh: sin ellas, el Chrome
+      # headless que Quarto usa para rasterizar los diagramas mermaid (p.ej.
+      # capitulos/01Introduccion.qmd) se queda colgado indefinidamente en vez
+      # de fallar, y el job termina agotando el tiempo hasta cancelarse.
+      - name: Install headless Chrome dependencies (mermaid rendering)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libatk1.0-0t64 \
+            libatk-bridge2.0-0t64 \
+            libatspi2.0-0t64 \
+            libdbus-1-3 \
+            libxcomposite1 \
+            libxdamage1 \
+            libxfixes3 \
+            libxrandr2 \
+            libgbm1 \
+            libxkbcommon0 \
+            libasound2t64 \
+            fonts-liberation
 
       # Execution results are frozen (_freeze/), so publishing needs neither
       # Python nor the TextClassification datasets it downloads at render


### PR DESCRIPTION
## Resumen

Después de mergear el fix de tinytex (#77), el siguiente run del workflow `Publish website` se quedó colgado ~1 hora renderizando `capitulos/01Introduccion.qmd` hasta que hubo que cancelarlo manualmente.

- Ese capítulo contiene un diagrama ` ```{mermaid} `. Para incluirlo en el PDF, Quarto lo rasteriza lanzando Chrome headless vía Puppeteer/Deno.
- Al runner de GitHub Actions le faltan las librerías de sistema que ese Chrome headless necesita (`libatk`, `libgbm`, `libdbus`, etc.) — las mismas que ya están documentadas e instaladas en `.devcontainer/postCreate.sh` para el entorno local/Codespaces, pero nunca se instalaron en `publish.yml`.
- Sin esas librerías, Chrome no crashea limpiamente: se queda colgado indefinidamente (se veían procesos huérfanos `chrome` y `chrome_crashpad_handler` en la limpieza del job al cancelarlo).

## Cambios

- `.github/workflows/publish.yml`: se agrega un step que instala las mismas librerías de `.devcontainer/postCreate.sh` antes de publicar.
- Se agrega `timeout-minutes: 20` al job `publish`, para que si algo similar vuelve a ocurrir, el job falle rápido con logs claros en vez de bloquear el runner (y la cola de `concurrency: group: website`) por una hora.

## Plan de prueba

- [ ] Verificar que el workflow `Publish website` corre completo (HTML + PDF) sin colgarse al hacer push/merge a `master`.
- [ ] Confirmar que el diagrama mermaid de `capitulos/01Introduccion.qmd` se rasteriza correctamente en el PDF publicado.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GagA8Gsk1jtdpBDgtGPBsZ)_