### PR TITLE
Evitar cuelgue del Chrome del sistema al rasterizar mermaid en el publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,8 @@ jobs:
           version: 1.10.18
           tinytex: true
 
-      # Mismas librerías que .devcontainer/postCreate.sh: sin ellas, el Chrome
-      # headless que Quarto usa para rasterizar los diagramas mermaid (p.ej.
-      # capitulos/01Introduccion.qmd) se queda colgado indefinidamente en vez
-      # de fallar, y el job termina agotando el tiempo hasta cancelarse.
+      # Mismas librerías que .devcontainer/postCreate.sh, por si el runner no
+      # las trae de fábrica.
       - name: Install headless Chrome dependencies (mermaid rendering)
         run: |
           sudo apt-get update -qq
@@ -44,6 +42,17 @@ jobs:
             libxkbcommon0 \
             libasound2t64 \
             fonts-liberation
+
+      # Sin esto, Quarto cae de vuelta al Chrome del sistema que trae
+      # ubuntu-latest (preinstalado para Selenium/Playwright) para rasterizar
+      # el diagrama mermaid de 01Introduccion.qmd a imagen (necesario para el
+      # PDF). Ese Chrome del sistema es una versión demasiado nueva/no
+      # verificada contra el cliente CDP que trae Quarto y se queda colgado
+      # sin avisar en vez de fallar (bug conocido en quarto-cli). Al instalar
+      # su propio Chrome Headless Shell (probado y fijado a esta versión de
+      # Quarto), este pasa a preferirse automáticamente sobre el del sistema.
+      - name: Install Chrome Headless Shell (mermaid rendering)
+        run: quarto install chrome-headless-shell --no-prompt --log-level warning
 
       # Execution results are frozen (_freeze/), so publishing needs neither
       # Python nor the TextClassification datasets it downloads at render


### PR DESCRIPTION
## Resumen

- El job `publish` se colgaba (~20-60 min) renderizando `capitulos/01Introduccion.qmd`, que contiene un diagrama ` ```{mermaid} `. Quarto necesita rasterizarlo a imagen para el PDF, y para eso lanza un navegador con protocolo CDP.
- Al no encontrar un Chrome Headless Shell propio instalado, Quarto caía de vuelta al Chrome del sistema preinstalado en `ubuntu-latest` (para Selenium/Playwright). Esa versión no es la que Quarto verifica/soporta y, en vez de fallar con un error claro, se queda colgada esperando una respuesta del protocolo que nunca llega (procesos huérfanos `chrome`/`chrome_crashpad_handler` confirmados en los logs del run cancelado).
- Se agrega `quarto install chrome-headless-shell`, que Quarto prefiere automáticamente sobre el navegador del sistema, evitando el cuelgue.
- Se mantiene `timeout-minutes: 20` en el job como red de seguridad para que una futura regresión falle rápido con logs claros en vez de bloquear el runner (y la cola de `concurrency: group: website`) por horas.

Este PR es continuación de los fixes de tinytex (#77) y de las librerías de sistema (#79) para el issue #76 — ninguno de los dos resolvía el cuelgue por completo.

## Test plan

- [ ] Verificar que el workflow `Publish website` corre en verde tras mergear (push a `master`).
- [ ] Confirmar en los logs que aparece el paso "Install Chrome Headless Shell" y que el render pasa `capitulos/01Introduccion.qmd` sin colgarse.
- [ ] Revisar que el sitio publicado en gh-pages incluye correctamente el diagrama mermaid y la descarga del PDF.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GagA8Gsk1jtdpBDgtGPBsZ)_